### PR TITLE
1 improve handling missing values

### DIFF
--- a/docs/source/api reference/data processing/synthpop_mq.data_processing.rst
+++ b/docs/source/api reference/data processing/synthpop_mq.data_processing.rst
@@ -1,13 +1,13 @@
 data\_processing
 =======================================
 
-.. py:module:: synthpop_mq.data_processing
+.. py:module:: synthpop_py.data_processing
 
 
 Encoder module
 --------------------------------------------
 
-.. automodule:: synthpop_mq.data_processing.Encoders
+.. automodule:: synthpop_py.data_processing.Encoders
    :members:
    :show-inheritance:
    :undoc-members:
@@ -16,7 +16,7 @@ Encoder module
 NullPredictor module
 --------------------------------------------------
 
-.. automodule:: synthpop_mq.data_processing.NullPredictor
+.. automodule:: synthpop_py.data_processing.MissingValuePredictor
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/source/api reference/synthesise methods/synthpop_mq.methods.rst
+++ b/docs/source/api reference/synthesise methods/synthpop_mq.methods.rst
@@ -1,13 +1,13 @@
 synthesise methods
 ==============================
 
-.. py:module:: synthpop_mq.methods
+.. py:module:: synthpop_py.methods
 
 
 XGBoost\_synth module
 ------------------------------------------
 
-.. automodule:: synthpop_mq.methods.XGBoost_synth
+.. automodule:: synthpop_py.methods.XGBoost_synth
    :members:
    :show-inheritance:
    :undoc-members:
@@ -15,7 +15,7 @@ XGBoost\_synth module
 base\_synth module
 ---------------------------------------
 
-.. automodule:: synthpop_mq.methods.base_synth
+.. automodule:: synthpop_py.methods.base_synth
    :members:
    :show-inheritance:
    :undoc-members:
@@ -24,7 +24,7 @@ base\_synth module
 cart\_synth module
 ---------------------------------------
 
-.. automodule:: synthpop_mq.methods.cart_synth
+.. automodule:: synthpop_py.methods.cart_synth
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/source/api reference/utility metrics/utility_metrics.rst
+++ b/docs/source/api reference/utility metrics/utility_metrics.rst
@@ -1,7 +1,7 @@
 Utility metrics
 ---------------------------------------
 
-.. automodule:: synthpop_mq.utility_metrics.spmse
+.. automodule:: synthpop_py.utility_metrics.spmse
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/source/functional descriptions/CART.md
+++ b/docs/source/functional descriptions/CART.md
@@ -1,0 +1,74 @@
+# Synthpop synthesis
+
+## 1. Introduction
+
+Classification And Regregression Trees (CART) can be used to generate synthetic data.
+This model can generate one column of data based on multiple other columns.
+The column that is to be generated is called the target. The columns used to generate the target are the features.
+
+## 2. Input and output
+
+The inputs for fitting a CART model are:
+- The features (a tabular dataset of original data with numeric and/or categorical columns used to predict the target)
+- The target (a one column table of original data)
+
+The inputs for generating synthetic data with a CART model are:
+- A synthetic version of the features used for fitting.
+
+The output is one column of synthetic data that is simular to the target.
+
+## 3. Detailed process
+
+The algorithm consists of two phases: 
+
+1. Fitting the synthesiser
+2. Generating a synthetic dataset
+
+### 3.1 Fitting the synthesiser
+
+A - Encoding categorical features
+
+Decision trees from scikit-learn do not run with categorical features, therefore those variables must be transformed into numeric variables. The default encoder in the synthpop synthesiser is based on the target variable: a mean encoder when the target is numeric and a PCA encoder when the target is categorical. A custom encoder can be specified when defining a specific regressor or a specific classifier. 
+
+For details about the default encoders, please refer to those pages: [mean encoding](Mean-encoding.md) or [PCA encoding](PCA-encoding.md). The encoders are fitted on all data, including rows where the target and/or feature are missing. 
+
+The next steps depend on wheter the target is numeric or categorical.
+
+#### 3.1.1 Fitting with a categorical target 
+
+If the target contains missing values, then the missing values are replaced by the value "N.a.N". If that value already occurs, an error should be raised and the process should stop. If there is already a "N.a.N" value and still missing values, there might be a problem with data quality.
+A decision tree classifier is fitted with the encoded feature and the transformed categorical target.
+
+#### 3.1.2 Fitting with a numeric target
+The [Missing Value Predictor](Null predictor.md) is fitted with the feature (without encodings) and target, without any modifications.
+combinations of feature and target where the target is missing are filtered out.
+A Decision tree regressor is fitted using the filtered feature and target. 
+
+
+### 3.2 Generating a synthetic dataset
+
+#### 3.2.1 Generating a numerical column
+- Use the missing value predictor on the already synthesised data to identify the rows where the target should be missing.
+For the rows for wich the target should not be missing:
+- Apply the same encoding used when fitting to the already synthesised categorical data.
+- Apply the fitted decision tree to the (encoded) already synthesised data to determine the leaf node that it corresponds to.
+- Draw a random sample from the data associated with the leaf node.
+
+#### 3.2.2 Generating a categorical column
+- Apply the same encoding used when fitting to the already synthesised categorical data.
+- Apply the fitted decision tree to the (encoded) already synthesised data to determine the leaf node that it corresponds to.
+- Draw a random sample from the data associated with the leaf node.
+- Replace the value "N.a.N" with missing value. 
+
+
+## 4. Mathematical properties and constraints
+
+Only numeric and categorical variables are supported. Other data types must be converted or removed before synthesis.
+
+## 5. Edge cases and special situations
+
+## 6. Limitations and considerations
+
+### 6.1 No prediction matrix
+
+In synthpop-R, users can configure a prediction matrix which specifies, for each variable, which previously synthesised variables should be included or excluded as predictors in the synthesis method. In the current version of synthpop-py, this level of control is not available: all variables synthesised earlier are automatically used as features in the model.

--- a/docs/source/functional descriptions/CART.md
+++ b/docs/source/functional descriptions/CART.md
@@ -1,4 +1,4 @@
-# Synthpop synthesis
+# CART synthesis model
 
 ## 1. Introduction
 

--- a/docs/source/functional descriptions/Mean-encoding.md
+++ b/docs/source/functional descriptions/Mean-encoding.md
@@ -64,6 +64,8 @@ Mean encoding produces exactly one numeric value per feature level. Therefore, t
 ### 5.1 Missing values
 If the feature is missing, the output of the encoding should be missing.
 If there is a non-missing value of the feature for which the target is always missing, the encoding should produce a missing value as well.
+If there is a non-missing value of the feature for which the target is sometimes but not always missing, the encoding should exlude the missing target values when calculating the mean.
+
 
 ## 6. Limitations and considerations
 Mean encoding assumes that the expected value of the target variable is informative for distinguishing between categories. The method is sensitive to outliers, rare categories, and data leakage.

--- a/docs/source/functional descriptions/Mean-encoding.md
+++ b/docs/source/functional descriptions/Mean-encoding.md
@@ -62,7 +62,8 @@ Mean encoding produces exactly one numeric value per feature level. Therefore, t
 
 ## 5. Edge cases and special situations
 ### 5.1 Missing values
-Missing target values are ignored when computing group means. Missing feature values must be handled before encoding. Possible strategies include removing observations with missing values, introducing an explicit "missing" category, or variable imputation.
+If the feature is missing, the output of the encoding should be missing.
+If there is a non-missing value of the feature for which the target is always missing, the encoding should produce a missing value as well.
 
 ## 6. Limitations and considerations
 Mean encoding assumes that the expected value of the target variable is informative for distinguishing between categories. The method is sensitive to outliers, rare categories, and data leakage.

--- a/docs/source/functional descriptions/Null predictor.md
+++ b/docs/source/functional descriptions/Null predictor.md
@@ -8,7 +8,7 @@ The Missing Value Predictor addresses this limitation by explicitly learning the
 
 ## 2. Input and output
 The Missing Value Predictor operates on the same inputs as the standard target predictor:
-- The original dataset $X$ with only numeric variables. Categorical variables need to be encoded before training the Missing Value Predictor.
+- The original dataset $X$.
 - A target vector $y$ that may contain missing values.
 
 The output is a Boolean vector $z \in \{0,1\}^n$, where  
@@ -25,10 +25,11 @@ This output is later used to decide whether a generated target value should be r
 ## 3. Detailed process
 For each target variable, the synthesis system trains two conceptually separate models. First, a value predictor that generates the target value assuming it is not missing. Then, a Missing Value Predictor that models the probability that the target is missing.
 
-The Missing Value Predictor is trained and used in 3 steps:
+The Missing Value Predictor is trained and used in 4 steps:
 1. Construction of the missingess target
-2. Training of the null classifier
-3. Probabilistic sampling
+2. Apply [mean encoding](Mean-encoding.md) to the categorical original data.
+3. Training of the null classifier
+4. Probabilistic sampling
 
 ### 3.1 Construction of the missingness target
 The target vector $y$ is transformed into a binary indicator vector $z$ such that
@@ -41,14 +42,17 @@ z_i =
 ```
 This new vector becomes the training target for the decision tree of the Missing Value Predictor.
 
-### 3.2 Training of the null classifier
-A binary decision tree classifier is trained on the original dataset $X$ and the binary missingness indicator $z$. For each observation $x$, the classifier estimates a conditional distribution. This is the empirical missingness rate of the training observations that ended up in that leaf:
+### 3.2 Apply mean encoding to the categorical original data.
+See [mean encoding](Mean-encoding.md). The boolean target value is interpreted here as a numeric value that is either 0 or 1. 
+
+### 3.3 Training of the null classifier
+A binary decision tree classifier is trained on the original encoded dataset $X$ and the binary missingness indicator $z$. For each observation $x$, the classifier estimates a conditional distribution. This is the empirical missingness rate of the training observations that ended up in that leaf:
 ```{math}
 P(z = 1 \mid x), \quad P(z = 0 \mid x).
 ```
 
-### 3.3 Probabilistic sampling
-During synthesis, the trained classifier outputs a probability vector for each input observation $x$ based on the leaf node in which $x$ falls. A Bernoulli sample is drawn from this probability vector to decide whether the target should be set to NaN.
+### 3.4 Probabilistic sampling
+During synthesis, the trained classifier outputs a probability vector for each input observation $x$ based on the leaf node in which $x$ falls. A Bernoulli sample is drawn from this probability vector to decide whether the target should be set to NaN. Note that the same encoding as used during fitting needs to be applied to the synthetic data before using the decision tree classifier.
 
 ## 4. Mathematical properties and constraints
 ### 4.1 Separation from value prediction
@@ -62,8 +66,6 @@ The Missing Value Predictor does not generate target values. It only determines 
 ```
 where $\hat{y}_i$ is produced by the standard predictor.
 
-### 4.2 Dependence on feature space
-The missingess model is conditional on the same feature representation used for value prediction. Therefore, any feature transformation or encoding applied to the value predictor must also be applied to the Missing Value Predictor.
 
 ## 5. Edge cases and special situations
 ### 5.1 No missing values

--- a/docs/source/functional descriptions/PCA-encoding.md
+++ b/docs/source/functional descriptions/PCA-encoding.md
@@ -45,7 +45,8 @@ Only the first $k$ principal components are kept as part of the encoding.
 
 ## 6. Edge cases and special situations
 ### 6.1 Missing values
-Traditional PCA does not accept any missing data points. Any missing values in the feature or target variables must be handled prior to constructing the contingency table. Possible strategies include removing observations with missing values, introducing an explicit "missing" category, or variable imputation.
+If the feature is missing, the output of the encoding should be missing.
+If there is a non-missing value of the feature for which the target is always missing, the encoding should produce a missing value as well.
 
 ### 6.2 Zero-variance columns
 If a column in the contingency table has zero variance, scaling cannot be applied. Such columns do not contribute to variance-based component selection and effectively do not influence the PCA result.

--- a/docs/source/functional descriptions/PCA-encoding.md
+++ b/docs/source/functional descriptions/PCA-encoding.md
@@ -47,6 +47,7 @@ Only the first $k$ principal components are kept as part of the encoding.
 ### 6.1 Missing values
 If the feature is missing, the output of the encoding should be missing.
 If there is a non-missing value of the feature for which the target is always missing, the encoding should produce a missing value as well.
+If there is a non-missing value of the feature for which the target is sometimes but not always missing, the encoding should treat a missing value as a value.
 
 ### 6.2 Zero-variance columns
 If a column in the contingency table has zero variance, scaling cannot be applied. Such columns do not contribute to variance-based component selection and effectively do not influence the PCA result.

--- a/docs/source/functional descriptions/SynthpopSynthesis.md
+++ b/docs/source/functional descriptions/SynthpopSynthesis.md
@@ -23,30 +23,14 @@ The algorithm consists of two phases:
 2. Generating a synthetic dataset
 
 ### 3.1 Fitting the synthesiser
-
-A - Encoding categorical features
-
-Decision trees from scikit-learn do not run with categorical features, therefore those variables must be transformed into numeric variables. The default encoder in the synthpop synthesiser is based on the target variable: a mean encoder when the target is numeric and a PCA encoder when the target is categorical. A custom encoder can be specified when defining a specific regressor or a specific classifier. 
-
-For details about the default encoders, please refer to those pages: [mean encoding](Mean-encoding.md) or [PCA encoding](PCA-encoding.md)
-
-B - Fitting decision tree
-
-A decision tree is fitted for the target variable, with the feature variables as predictors. Rows where the target column is empty are ignored. The decision tree is applied to the original data. The combination of the leaf node and the value of the target column is stored for every row in the original data.
-
-C - Fitting binary classifier
-
-A decision tree classifier is fitted. The predictors are all the features of the target column. The prediction target of this classifier is a Boolean indicating whether the target is empty or not.
+For each column, a model is fitted in the order specified above. All previous columns are the features, the current column is the target.
+The default model is [CART](CART.md)
 
 ### 3.2 Generating a synthetic dataset
 
 The synthetic dataset is generated incrementally, column by column:
 1. The first column is synthesised by taking a sample with replacement of the user specified number of rows. 
-2. Subsequent target columns:
-- Apply the fitted decision tree to the already synthesised data to determine the leaf node that it corresponds to.
-- Draw a random sample from the data associated with the leaf node.
-- Use the fitted binary classifier to predict the probability of the target being empty.
-- Sample from the probability calculated in step 3. If true, the target value is set to missing, else the value from step 2 is used.
+2. For subsequent models, the fitted model is used to generate synthetic data using the data that has already be synthesised. 
 
 ## 4. Mathematical properties and constraints
 

--- a/docs/source/functional descriptions/fd_index.md
+++ b/docs/source/functional descriptions/fd_index.md
@@ -4,6 +4,7 @@ This documentation is used by developers to implement this package. It can be ve
 :maxdepth: 1
 
 SynthpopSynthesis.md
+CART.md
 Mean-encoding.md
 PCA-encoding.md
 Null predictor.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ documentation for details.
    :caption: Contents:
 
    intro
-   synthpop_mq
+   synthpop_py
    user guides/examples
    functional descriptions/fd_index
    developing

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,7 +1,7 @@
-synthpop_mq
+synthpop_py
 ===========
 
 .. toctree::
    :maxdepth: 4
 
-   synthpop_mq
+   synthpop_py

--- a/docs/source/synthpop_py.rst
+++ b/docs/source/synthpop_py.rst
@@ -1,4 +1,4 @@
-synthpop\_mq package
+synthpop\_py package
 ====================
 
 Subpackages
@@ -13,10 +13,10 @@ Subpackages
 
 
 
-synthpop\_mq.Synthesiser module
+synthpop\_py.Synthesiser module
 -------------------------------
 
-.. automodule:: synthpop_mq.Synthesiser
+.. automodule:: synthpop_py.Synthesiser
    :members:
    :show-inheritance:
    :undoc-members:

--- a/src/synthpop_py/Synthesiser.py
+++ b/src/synthpop_py/Synthesiser.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from synthpop_mq.methods.base_synth import BaseSynthMethod
-from synthpop_mq.methods.cart_synth import TreeRegressorMethod, CartMethod
+from synthpop_py.methods.base_synth import BaseSynthMethod
+from synthpop_py.methods.cart_synth import TreeRegressorMethod, CartMethod
 from collections.abc import Callable
 from typing import Self
 

--- a/src/synthpop_py/methods/XGBoost_synth.py
+++ b/src/synthpop_py/methods/XGBoost_synth.py
@@ -1,4 +1,4 @@
-from synthpop_mq.methods import base_synth
+from synthpop_py.methods import base_synth
 import pandas as pd
 
 class XGBRegressorSynth(base_synth.BaseSynthMethod):

--- a/src/synthpop_py/methods/cart_synth.py
+++ b/src/synthpop_py/methods/cart_synth.py
@@ -1,6 +1,6 @@
 from numpy.random import RandomState
-from synthpop_mq.data_processing.Encoders import PCAEncoder, MeanEncoder
-from synthpop_mq.methods import base_synth
+from synthpop_py.data_processing.Encoders import PCAEncoder, MeanEncoder
+from synthpop_py.methods import base_synth
 import pandas as pd
 from typing import Literal, Mapping, Self, Sequence
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor


### PR DESCRIPTION
closes #1 

These changes focus on what happens when a categorical feature is used to predict a target with missing values.

Compare how the Decision tree regressor, decision tree classifier, PCA encoder, and mean encoder deal with missing values. Each of those uses a different strategy. Are these strategies consistent with eachother? Does this make sense?