### PR TITLE
90 implement cart method

### DIFF
--- a/src/synthpop/methods/cart_synth.py
+++ b/src/synthpop/methods/cart_synth.py
@@ -15,7 +15,7 @@ from synthpop.data_processing.missing_value_handling import BaseMissingValueHand
 from synthpop.methods import base_synth
 from synthpop.methods.tree_utils import LeafNodeSampler
 import synthpop.methods.tree_utils as tree_utils
-from synthpop.utils import validate_y, validate_dict_x
+from synthpop.utils import validate_y, validate_dict_x,str_dtype
 
 
 class _AbstractTreeMethod(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
@@ -291,9 +291,15 @@ class CartMethod(base_synth.BaseSynthMethod):
         # X, y = validate_data(self, X, y)
 
         # The return values of (TreeRegressorMethod/TreeClassifierMethod).fit() should be stored in an attribute that ends in an underscore.
-        # In this way, the check_is_fitted method still works. See https://scikit-learn.org/stable/modules/generated/sklearn.utils.validation.check_is_fitted.html#sklearn.utils.validation.check_is_fitted
+        # In this way, the check_is_fitted method still works. See https://scikit-learn.org/stable/modules/generated/sklearn.utils.validation.check_is_fitted.html#sklearn.utils.validation.check_is_
 
-        return conventionalize_x_data(X)
+        x_clean = conventionalize_x_data(X)
+        y_clean = conventionalize_1d_array_like(y)
+
+        if y_clean.dtype == str_dtype:
+            self.classi.fit(x_clean,y_clean)
+        else:
+            self.reg.fit(x_clean,y_clean)
 
         return self
 

--- a/src/synthpop/methods/cart_synth.py
+++ b/src/synthpop/methods/cart_synth.py
@@ -275,8 +275,8 @@ class CartMethod(base_synth.BaseSynthMethod):
     def __init__(self, regressor: TreeRegressorMethod | None = None, classifier: TreeClassifierMethod | None = None) -> None:
         super().__init__()
         # see https://scikit-learn.org/stable/developers/develop.html#instantiation
-        self.reg = regressor
-        self.classi = classifier
+        self.regressor = regressor
+        self.classifier = classifier
 
         # parameters of TreeRegressorMethod and TreeClassifierMethod should not be set in this __init__, for consistency:
         # The user could specify contradicting values.
@@ -303,9 +303,11 @@ class CartMethod(base_synth.BaseSynthMethod):
         y_clean = conventionalize_1d_array_like(y)
 
         if y_clean.dtype == str_dtype:
-            self.classi.fit(x_clean,y_clean)
+            self.classifier_ = clone(self.classifier).fit(x_clean,y_clean)
+            self.regressor_ = None
         else:
-            self.reg.fit(x_clean,y_clean)
+            self.regressor_ = clone(self.regressor).fit(x_clean,y_clean)
+            self.classifier_ = None 
 
         return self
 

--- a/src/synthpop/methods/cart_synth.py
+++ b/src/synthpop/methods/cart_synth.py
@@ -242,6 +242,19 @@ class TreeRegressorMethod(_AbstractTreeMethod):
                                       ,)
 
 
+def conventionalize_x_data(X)->dict[str, npt.ArrayLike]:
+    
+    if isinstance(X,pd.DataFrame):
+        X_d = X.to_dict()
+    else:
+        X_d = X
+    
+    return {k:np.asanyarray(v) for k,v in X_d.items()}
+
+def conventionalize_1d_array_like(y)-> np.ndarray:
+    return np.asanyarray(y)
+
+
 class CartMethod(base_synth.BaseSynthMethod):
     """
     Assigns the right decision tree model based on the target variable data type: if numeric, we use a regressor, if categorical, we use a classifier.
@@ -279,6 +292,8 @@ class CartMethod(base_synth.BaseSynthMethod):
 
         # The return values of (TreeRegressorMethod/TreeClassifierMethod).fit() should be stored in an attribute that ends in an underscore.
         # In this way, the check_is_fitted method still works. See https://scikit-learn.org/stable/modules/generated/sklearn.utils.validation.check_is_fitted.html#sklearn.utils.validation.check_is_fitted
+
+        return conventionalize_x_data(X)
 
         return self
 

--- a/src/synthpop/methods/cart_synth.py
+++ b/src/synthpop/methods/cart_synth.py
@@ -249,10 +249,16 @@ def conventionalize_x_data(X)->dict[str, npt.ArrayLike]:
     else:
         X_d = X
     
-    return {k:np.asanyarray(v) for k,v in X_d.items()}
+    return {k: conventionalize_1d_array_like(v) for k,v in X_d.items()}
 
 def conventionalize_1d_array_like(y)-> np.ndarray:
-    return np.asanyarray(y)
+    y_arr = np.asanyarray(y)
+
+    if not pd.api.types.is_numeric_dtype(y_arr.dtype):
+        na_mask = pd.isna(y)
+        return np.array([v if not pd.isna(v) else np.nan for v in y],dtype=str_dtype)
+
+    return y_arr.astype(np.float32)
 
 
 class CartMethod(base_synth.BaseSynthMethod):

--- a/tests/unit/test_cart_classifier_synth.py
+++ b/tests/unit/test_cart_classifier_synth.py
@@ -1,16 +1,67 @@
+"""
+Requirements:
+
+- input can be "dirty" pandas dataframes/series
+- input numpy arrays supported?
+- implements set_output api
+- passes only (dicts of) numpy arrays with correct dtypes to its dependencies
+- selects correct tree method
+
+- tune_cart method
 
 
+Approach:
+- one function that "cleans" data
+- assert that CartMethod uses that function and delegates correctly.
+"""
+import pandas as pd
+import numpy as np
+from synthpop.methods.cart_synth import CartMethod
+import pytest
 
-from synthpop.methods.cart_synth import TreeClassifierMethod
+
+class StubTreeMethod():
+    def __init__(self,transform_result):
+        self.transform_result = transform_result
+
+    def fit(self,X,y):
+        self.fit_x = X
+        self.fit_y = y
+        return self
+
+    def transform(self,X):
+        self.transform_x = X
+        return self.transform_result
+    
+
+def test_cartmethod_fit_dataflow_classifier(mocker):
+    #TODO: test over cat target and num target
+
+    exp_result = np.array([1,2,3])
+    classi_tree_method = StubTreeMethod(transform_result=exp_result)
+    reg_tree_method = StubTreeMethod(transform_result=exp_result)
+
+    clean_X = {}
+    clean_y = []
+
+    mocked_conventionalise_x = mocker.patch('synthpop.methods.cart_synth.conventionalize_x_data',return_value=clean_X)
+    mocked_conventionalise_y = mocker.patch('synthpop.methods.cart_synth.conventionalize_1d_array_like',return_value=clean_y)
+
+    X = {
+        "a":[1,2,3,4]
+    }
+    y = [1,1,2,2]
+
+    cart = CartMethod(regressor=reg_tree_method,classifier=classi_tree_method)
+
+    fit_res = cart.fit(X,y)
+
+    assert fit_res is cart
+
+    mocked_conventionalise_x.assert_called_with(X)
+    mocked_conventionalise_y.assert_called_with(y)
+
+    #TODO: assert delegation to tree methods
 
 
-def func(x):
-    return x + 1
-
-
-def test_answer():
-    assert func(3) == 5
-
-def test_datatype_sanity():
-    obj = TreeClassifierMethod()
-    assert type(obj) is TreeClassifierMethod
+#TODO: test get_feature_names_out. 

--- a/tests/unit/test_cart_classifier_synth.py
+++ b/tests/unit/test_cart_classifier_synth.py
@@ -18,7 +18,7 @@ import pandas as pd
 import numpy as np
 from synthpop.methods.cart_synth import CartMethod
 import pytest
-
+str_dtype = np.dtypes.StringDType(na_object=np.nan)
 
 class StubTreeMethod():
     def __init__(self,transform_result):
@@ -33,26 +33,30 @@ class StubTreeMethod():
         self.transform_x = X
         return self.transform_result
     
-
-def test_cartmethod_fit_dataflow_classifier(mocker):
+@pytest.mark.parametrize("y_clean,cat_target",[(np.array([1,2,3],dtype=np.float32),False),
+                                               (np.array(["a","2","3"],dtype=str_dtype),True)
+                                               ])
+def test_cartmethod_fit_dataflow_classifier(y_clean,cat_target,mocker):
     #TODO: test over cat target and num target
 
     exp_result = np.array([1,2,3])
-    classi_tree_method = StubTreeMethod(transform_result=exp_result)
-    reg_tree_method = StubTreeMethod(transform_result=exp_result)
+    tree_method = StubTreeMethod(transform_result=exp_result)
 
     clean_X = {}
     clean_y = []
 
     mocked_conventionalise_x = mocker.patch('synthpop.methods.cart_synth.conventionalize_x_data',return_value=clean_X)
-    mocked_conventionalise_y = mocker.patch('synthpop.methods.cart_synth.conventionalize_1d_array_like',return_value=clean_y)
+    mocked_conventionalise_y = mocker.patch('synthpop.methods.cart_synth.conventionalize_1d_array_like',return_value=y_clean)
 
     X = {
         "a":[1,2,3,4]
     }
     y = [1,1,2,2]
 
-    cart = CartMethod(regressor=reg_tree_method,classifier=classi_tree_method)
+    if cat_target:
+        cart = CartMethod(classifier=tree_method)
+    else:
+        cart = CartMethod(regressor=tree_method)
 
     fit_res = cart.fit(X,y)
 
@@ -61,7 +65,8 @@ def test_cartmethod_fit_dataflow_classifier(mocker):
     mocked_conventionalise_x.assert_called_with(X)
     mocked_conventionalise_y.assert_called_with(y)
 
-    #TODO: assert delegation to tree methods
+    assert tree_method.fit_x == clean_X
+    assert np.array_equal(tree_method.fit_y, y_clean)
 
 
 #TODO: test get_feature_names_out. 

--- a/tests/unit/test_cart_classifier_synth.py
+++ b/tests/unit/test_cart_classifier_synth.py
@@ -37,7 +37,6 @@ class StubTreeMethod():
                                                (np.array(["a","2","3"],dtype=str_dtype),True)
                                                ])
 def test_cartmethod_fit_dataflow_classifier(y_clean,cat_target,mocker):
-    #TODO: test over cat target and num target
 
     exp_result = np.array([1,2,3])
     tree_method = StubTreeMethod(transform_result=exp_result)
@@ -69,4 +68,6 @@ def test_cartmethod_fit_dataflow_classifier(y_clean,cat_target,mocker):
     assert np.array_equal(tree_method.fit_y, y_clean)
 
 
-#TODO: test get_feature_names_out. 
+#TODO: test get_feature_names_out.
+#TODO: test cloning of tree methods
+#TODO: implement cloning of CartMethod 

--- a/tests/unit/test_cart_classifier_synth.py
+++ b/tests/unit/test_cart_classifier_synth.py
@@ -18,9 +18,10 @@ import pandas as pd
 import numpy as np
 from synthpop.methods.cart_synth import CartMethod
 import pytest
+from sklearn.base import BaseEstimator, TransformerMixin
 str_dtype = np.dtypes.StringDType(na_object=np.nan)
 
-class StubTreeMethod():
+class StubTreeMethod(TransformerMixin, BaseEstimator):
     def __init__(self,transform_result):
         self.transform_result = transform_result
 
@@ -64,8 +65,15 @@ def test_cartmethod_fit_dataflow_classifier(y_clean,cat_target,mocker):
     mocked_conventionalise_x.assert_called_with(X)
     mocked_conventionalise_y.assert_called_with(y)
 
-    assert tree_method.fit_x == clean_X
-    assert np.array_equal(tree_method.fit_y, y_clean)
+    if cat_target:
+        assert cart.classifier_.fit_x == clean_X
+        assert np.array_equal(cart.classifier_.fit_y, y_clean)
+    else:
+        assert cart.regressor_.fit_x == clean_X
+        assert np.array_equal(cart.regressor_.fit_y, y_clean)
+
+    assert not (cart.regressor_ is tree_method)
+    assert not (cart.classifier_ is tree_method)
 
 
 #TODO: test get_feature_names_out.

--- a/tests/unit/test_conventionalise_data.py
+++ b/tests/unit/test_conventionalise_data.py
@@ -1,0 +1,45 @@
+
+import pandas as pd
+import numpy as np
+from synthpop.methods.cart_synth import CartMethod,conventionalize_x_data,conventionalize_1d_array_like
+import pytest
+
+def get_x_input_data():
+    #TODO: more input types
+    x_dict = {
+        "a": [1,2,3],
+        "b": ["x","y","z"]
+    }
+
+    x_dataframe = pd.DataFrame(x_dict)
+
+    return [x_dict,x_dataframe]
+
+def get_one_var_data():
+    #TODO: more input types
+    y1 = pd.Series(["a","b","c"])
+    return [y1]
+
+
+@pytest.mark.parametrize("X",get_x_input_data())
+def test_conventionalize_output_is_dict(X):
+
+    result =conventionalize_x_data(X)
+
+    assert isinstance(result,dict)
+
+    for (k,v) in result.items():
+        assert isinstance(k,str)
+        assert isinstance(v,np.ndarray)
+
+@pytest.mark.parametrize("y",get_one_var_data())
+def test_conventionalize_output_is_dict(y):
+
+    result =conventionalize_1d_array_like(y)
+
+    assert isinstance(result,np.ndarray)
+
+#TODO: test normalisation of different missings
+#TODO: assert shapes
+
+

--- a/tests/unit/test_conventionalise_data.py
+++ b/tests/unit/test_conventionalise_data.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 from synthpop.methods.cart_synth import CartMethod,conventionalize_x_data,conventionalize_1d_array_like
 import pytest
+str_dtype = np.dtypes.StringDType(na_object=np.nan)
 
 def get_x_input_data():
     #TODO: more input types
@@ -15,14 +16,32 @@ def get_x_input_data():
 
     return [x_dict,x_dataframe]
 
-def get_one_var_data():
+def get_one_var_data_str():
     #TODO: more input types
-    y1 = pd.Series(["a","b","c"])
-    return [y1]
+    
+    return [
+        pd.Series(["a","b","c"]),
+        ["a","b"],
+        pd.Series(["a",pd.NA,"c"]),
+        np.array(["a",np.nan,"b"],dtype=str_dtype),
+    ]
 
+def get_one_var_data_num():
+    #TODO: more input types
+    
+    return [
+        pd.Series([1,2,3]),
+        [1.1,2.2],
+        pd.Series([1,np.nan,2]),
+        np.array([1.2,np.nan,3.4],dtype=np.float32),
+    ]
 
 @pytest.mark.parametrize("X",get_x_input_data())
-def test_conventionalize_output_is_dict(X):
+def test_conventionalize_output_is_dict(X,mocker):
+
+    clean_column = np.array([1,2,3])
+
+    mocked_conventionalise_y = mocker.patch('synthpop.methods.cart_synth.conventionalize_1d_array_like',return_value=clean_column)
 
     result =conventionalize_x_data(X)
 
@@ -30,16 +49,39 @@ def test_conventionalize_output_is_dict(X):
 
     for (k,v) in result.items():
         assert isinstance(k,str)
-        assert isinstance(v,np.ndarray)
+        assert np.array_equal(v,clean_column)
 
-@pytest.mark.parametrize("y",get_one_var_data())
-def test_conventionalize_output_is_dict(y):
+    mocked_conventionalise_y.assert_called()
+
+@pytest.mark.parametrize("y",get_one_var_data_str())
+def test_conventionalize_y_output_is_np_array(y):
 
     result =conventionalize_1d_array_like(y)
 
     assert isinstance(result,np.ndarray)
 
+@pytest.mark.parametrize("y",get_one_var_data_str())
+def test_conventionalize_cat_y_output_is_np_array_string_dytpe(y):
+
+    result =conventionalize_1d_array_like(y)
+
+    assert result.dtype == str_dtype
+
+    #str_dtype has exactly one way of representing missing values: np.nan.
+    #So if the dtype of result is str_dtype and the missingness pattern aligns, then the conversion was succesfull.
+    assert np.array_equal(pd.isna(y),pd.isna(result)), "missings are not handled correctly"
+
+@pytest.mark.parametrize("y",get_one_var_data_num())
+def test_conventionalize_cat_y_output_is_np_array_float32(y):
+
+    result =conventionalize_1d_array_like(y)
+
+    assert result.dtype == np.float32
+
+    
 #TODO: test normalisation of different missings
+#TODO: test numeric dtypes
+#TODO: test shape (2D).
 #TODO: assert shapes
 
 

--- a/tests/unit/test_conventionalise_data.py
+++ b/tests/unit/test_conventionalise_data.py
@@ -78,10 +78,6 @@ def test_conventionalize_cat_y_output_is_np_array_float32(y):
 
     assert result.dtype == np.float32
 
-    
-#TODO: test normalisation of different missings
-#TODO: test numeric dtypes
 #TODO: test shape (2D).
-#TODO: assert shapes
 
 


### PR DESCRIPTION
Requirements:

- input can be "dirty" pandas dataframes/series
- input numpy arrays supported?
- implements set_output api
- passes only (dicts of) numpy arrays with correct dtypes to its dependencies
- selects correct tree method

- tune_cart method


Approach:
- one function that "cleans" data 
- assert that CartMethod uses that function and delegates correctly.