### PR TITLE
152 bug cart method does not work with nan array

### DIFF
--- a/src/synthpop/methods/cart_synth.py
+++ b/src/synthpop/methods/cart_synth.py
@@ -11,6 +11,7 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, TransformerMixin, check_is_fitted
 from sklearn.decomposition import PCA
 from sklearn.tree import BaseDecisionTree, DecisionTreeClassifier, DecisionTreeRegressor
+from sklearn.exceptions import NotFittedError
 
 from synthpop import utils
 import synthpop.methods.tree_utils as tree_utils
@@ -86,12 +87,12 @@ class _AbstractTreeMethod(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
         y = utils.validate_1d_target(y, n_samples)
         self._all_missing = False
 
+        self.n_features_in_ = len(X.keys())
+        self.feature_order_ = list(X.keys())
+
         if pd.isna(y).all():
             self._all_missing = True
             return self
-
-        self.n_features_in_ = len(X.keys())
-        self.feature_order_ = list(X.keys())
 
         self.encoders_ = {name: self._new_encoder().fit(value, y) for (
             name, value) in X_val.items() if not pd.api.types.is_numeric_dtype(value.dtype)}
@@ -123,6 +124,12 @@ class _AbstractTreeMethod(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
 
         """
 
+        if not hasattr(self, '_all_missing'):
+            raise NotFittedError
+        elif self._all_missing:
+            return np.array([np.nan]*len(X[next(iter(X))]))
+
+        
         # Apply encoding, sample, apply (inverse) handling of missing values.
         check_is_fitted(
             self, 
@@ -418,13 +425,6 @@ class CartMethod(base_synth.BaseSynthMethod):
         :param X: Feature dataset.
         :return: Synthesised target variable.
         """
-
-        if hasattr(self, "method_") and getattr(self.method_, "_all_missing", False):
-            return pd.Series(
-            np.nan,
-            index=X.index,
-            name=self.target_name_,
-        )
 
         check_is_fitted(self, ["method_", "feature_names_in_", "target_name_"])
 

--- a/src/synthpop/methods/cart_synth.py
+++ b/src/synthpop/methods/cart_synth.py
@@ -419,7 +419,7 @@ class CartMethod(base_synth.BaseSynthMethod):
         :return: Synthesised target variable.
         """
 
-        if self.method_._all_missing:
+        if hasattr(self, "method_") and getattr(self.method_, "_all_missing", False):
             return pd.Series(
             np.nan,
             index=X.index,

--- a/src/synthpop/methods/cart_synth.py
+++ b/src/synthpop/methods/cart_synth.py
@@ -84,6 +84,11 @@ class _AbstractTreeMethod(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
         self.target_name_ = getattr(y, "name", None)
         X_val, n_samples = utils.validate_2d_dict(X)
         y = utils.validate_1d_target(y, n_samples)
+        self._all_missing = False
+
+        if pd.isna(y).all():
+            self._all_missing = True
+            return self
 
         self.n_features_in_ = len(X.keys())
         self.feature_order_ = list(X.keys())
@@ -413,6 +418,13 @@ class CartMethod(base_synth.BaseSynthMethod):
         :param X: Feature dataset.
         :return: Synthesised target variable.
         """
+
+        if self.method_._all_missing:
+            return pd.Series(
+            np.nan,
+            index=X.index,
+            name=self.target_name_,
+        )
 
         check_is_fitted(self, ["method_", "feature_names_in_", "target_name_"])
 

--- a/tests/integration/test_int_bugfix_152.py
+++ b/tests/integration/test_int_bugfix_152.py
@@ -1,0 +1,34 @@
+"""
+This file is a placeholder for another issue:
+
+135-implement-more-integration tests
+
+This test is also present in the current version of that branch, where it failed.
+
+This file should be deleted when issue 135 merges with the develop branch
+"""
+
+from synthpop.synthesiser import Synthesiser
+from synthpop.methods.cart_synth import CartMethod
+from synthpop.methods.copy_synth import CopyMethod
+from synthpop.methods.sample_synth import SampleMethod
+
+import pandas as pd
+import numpy as np
+import pytest
+
+def test_int_bugfix_152():
+    df = pd.DataFrame({
+    "a": [1, None],
+    "b": [0, 0],
+    "c": [np.nan, np.nan]
+    })
+
+    special_syn_method = {
+    "a": SampleMethod(),
+    "b": CopyMethod(),
+    "c": CartMethod()
+    }
+
+    synth = Synthesiser(random_seed=2, special_syn_method=special_syn_method)
+    fit = synth.fit(df)

--- a/tests/integration/test_int_cart_method.py
+++ b/tests/integration/test_int_cart_method.py
@@ -262,3 +262,24 @@ def test_fit_transform_with_missing_values_in_target(y):
 
     assert len(out) == len(y)
     assert out.isna().sum() > 0
+
+    
+@pytest.mark.parametrize(
+    "y",
+    [
+        (pd.Series([None, None], name='c')),
+        (pd.Series([np.nan, np.nan], name='c')),
+        (pd.Series([pd.NA, pd.NA], name='c'))
+    ]
+)
+def test_fitting_handles_entire_nan_array(y):
+    cart = CartMethod()
+
+    X = pd.DataFrame({
+        "a": [1, 2],
+        "b": [3, 4],
+    })
+
+    res = cart.fit(X, y)
+    assert res.method_._all_missing == True
+    assert res.target_name_ == 'c'

--- a/tests/unit/test_cart.py
+++ b/tests/unit/test_cart.py
@@ -12,6 +12,7 @@ from synthpop.utils import str_dtype
 class StubRegressor(TransformerMixin, BaseEstimator):
     def __init__(self, transform_result=None):
         self.transform_result = transform_result
+        self._all_missing = False
 
     def fit(self, X, y):
         self.fit_x = X
@@ -29,6 +30,7 @@ class StubRegressor(TransformerMixin, BaseEstimator):
 class StubClassifier(TransformerMixin, BaseEstimator):
     def __init__(self, transform_result=None):
         self.transform_result = transform_result
+        self._all_missing = False
 
     def fit(self, X, y):
         self.fit_x = X

--- a/tests/unit/test_cart.py
+++ b/tests/unit/test_cart.py
@@ -140,7 +140,9 @@ def test_fitting_handles_entire_nan_array(y):
 
     res = cart.fit(X, y)
     assert res.method_._all_missing == True
-    assert hasattr(res, 'target_name_')
+    assert res.target_name_ == 'c'
+    assert hasattr(res.method_, 'n_features_in_')
+    assert hasattr(res.method_, 'feature_order_')
     assert not hasattr(cart, "__sklearn_is_fitted__")
 
 
@@ -364,8 +366,6 @@ def test_transform_requires_fit():
     with pytest.raises(NotFittedError):
         cart.transform(pd.DataFrame({"a": [1]}))
 
-
-
 @pytest.mark.parametrize(
     "y",
     [
@@ -375,15 +375,19 @@ def test_transform_requires_fit():
 
     ]
 )
-def test_bypass_entire_nan_array(y):
-    cart = CartMethod()
+def test_transform_when_fitted_on_all_missing_outputs_all_missing(y):
+    cart = CartMethod(regressor=StubRegressor(), classifier=StubClassifier())
+
+    cart.method_ = StubRegressor()
+    cart.feature_names_in_ = ["a", "b"]
+    cart.target_name_ = "target"
 
     X = pd.DataFrame({
         "a": [1, 2, 3],
         "b": [4, 5, 6],
     })
 
-    cart.fit(X, y)
+    cart.method_._all_missing = True
     result = cart.transform(X)
 
     assert pd.isna(result).all()

--- a/tests/unit/test_cart.py
+++ b/tests/unit/test_cart.py
@@ -121,31 +121,6 @@ def test_fit_passes_standardised_data_to_tree(mocker):
     assert cart.method_.fit_x is clean_X
     assert cart.method_.fit_y is clean_y
 
-
-@pytest.mark.parametrize(
-    "y",
-    [
-        (pd.Series([None, None], name='c')),
-        (pd.Series([np.nan, np.nan], name='c')),
-        (pd.Series([pd.NA, pd.NA], name='c'))
-    ]
-)
-def test_fitting_handles_entire_nan_array(y):
-    cart = CartMethod()
-
-    X = pd.DataFrame({
-        "a": [1, 2],
-        "b": [3, 4],
-    })
-
-    res = cart.fit(X, y)
-    assert res.method_._all_missing == True
-    assert res.target_name_ == 'c'
-    assert hasattr(res.method_, 'n_features_in_')
-    assert hasattr(res.method_, 'feature_order_')
-    assert not hasattr(cart, "__sklearn_is_fitted__")
-
-
 @pytest.mark.parametrize(
     ("y", "expected_type"),
     [

--- a/tests/unit/test_cart.py
+++ b/tests/unit/test_cart.py
@@ -21,10 +21,10 @@ class StubRegressor(TransformerMixin, BaseEstimator):
     def transform(self, X):
         self.transform_x = X
         return self.transform_result
-    
+
     def get_feature_names_out(self, input_features=None):
         return ["fake_output"]
-    
+
 
 class StubClassifier(TransformerMixin, BaseEstimator):
     def __init__(self, transform_result=None):
@@ -38,7 +38,7 @@ class StubClassifier(TransformerMixin, BaseEstimator):
     def transform(self, X):
         self.transform_x = X
         return self.transform_result
-    
+
     def get_feature_names_out(self, input_features=None):
         return ["fake_output"]
 
@@ -48,8 +48,10 @@ class StubClassifier(TransformerMixin, BaseEstimator):
     ("X", "y", "expected", "message"),
     [
         ({}, pd.Series([1]), TypeError, "X must be a pandas DataFrame"),
-        (pd.DataFrame({"a": [1]}), [1], TypeError, "y must be a pandas Series"),
-        (pd.DataFrame({"a": [1, 2]}), pd.Series([1]), ValueError, "X and y must contain the same number of samples"),
+        (pd.DataFrame({"a": [1]}), [1],
+         TypeError, "y must be a pandas Series"),
+        (pd.DataFrame({"a": [1, 2]}), pd.Series(
+            [1]), ValueError, "X and y must contain the same number of samples"),
     ],
 )
 def test_fit_validates_inputs(X, y, expected, message):
@@ -57,6 +59,7 @@ def test_fit_validates_inputs(X, y, expected, message):
 
     with pytest.raises(expected, match=message):
         cart.fit(X, y)
+
 
 @pytest.mark.parametrize(
     ("y_array", "expected_type"),
@@ -88,6 +91,7 @@ def test_fit_selects_correct_method(mocker, y_array, expected_type):
     assert isinstance(cart.method_, expected_type)
     assert np.array_equal(cart.method_.fit_y, y_array)
 
+
 def test_fit_passes_standardised_data_to_tree(mocker):
     clean_X = {"a": np.array([1, 2, 3], dtype=np.float32)}
     clean_y = np.array([4, 5, 6], dtype=np.float32)
@@ -115,6 +119,29 @@ def test_fit_passes_standardised_data_to_tree(mocker):
     assert cart.method_.fit_x is clean_X
     assert cart.method_.fit_y is clean_y
 
+
+@pytest.mark.parametrize(
+    "y",
+    [
+        (pd.Series([None, None], name='c')),
+        (pd.Series([np.nan, np.nan], name='c')),
+        (pd.Series([pd.NA, pd.NA], name='c'))
+    ]
+)
+def test_fitting_handles_entire_nan_array(y):
+    cart = CartMethod()
+
+    X = pd.DataFrame({
+        "a": [1, 2],
+        "b": [3, 4],
+    })
+
+    res = cart.fit(X, y)
+    assert res.method_._all_missing == True
+    assert hasattr(res, 'target_name_')
+    assert not hasattr(cart, "__sklearn_is_fitted__")
+
+
 @pytest.mark.parametrize(
     ("y", "expected_type"),
     [
@@ -132,11 +159,12 @@ def test_fit_clones_methods(y, expected_type):
     cart.fit(X, y)
 
     assert isinstance(cart.method_, expected_type)
-    
+
     if expected_type is StubRegressor:
         assert cart.method_ is not regressor
     else:
         assert cart.method_ is not classifier
+
 
 @pytest.mark.parametrize(
     "y",
@@ -179,15 +207,20 @@ def test_fit_sets_fitted_attributes(mocker, y):
     assert cart.method_.fit_y is clean_y
 
 # ----- transform tests -----
+
+
 @pytest.mark.parametrize(
     ("result", "method"),
     [
-        (pd.Series([10, 20]), StubRegressor(transform_result=np.array([10, 20]))),
-        (pd.Series(["a", "b"]), StubClassifier(transform_result=np.array(["a", "b"]))),
+        (pd.Series([10, 20]), StubRegressor(
+            transform_result=np.array([10, 20]))),
+        (pd.Series(["a", "b"]), StubClassifier(
+            transform_result=np.array(["a", "b"]))),
     ]
 )
 def test_transform_returns_series(mocker, result, method):
-    cart = CartMethod(regressor=StubRegressor(result), classifier=StubClassifier(result))
+    cart = CartMethod(regressor=StubRegressor(result),
+                      classifier=StubClassifier(result))
 
     cart.feature_names_in_ = ["a"]
     cart.target_name_ = "target"
@@ -216,15 +249,19 @@ def test_transform_returns_series(mocker, result, method):
 
     np.testing.assert_array_equal(out.to_numpy(), result)
 
+
 @pytest.mark.parametrize(
     ("result", "method"),
     [
-        (pd.Series([10, 20]), StubRegressor(transform_result=np.array([10, 20]))),
-        (pd.Series(["a", "b"]), StubClassifier(transform_result=np.array(["a", "b"]))),
+        (pd.Series([10, 20]), StubRegressor(
+            transform_result=np.array([10, 20]))),
+        (pd.Series(["a", "b"]), StubClassifier(
+            transform_result=np.array(["a", "b"]))),
     ]
 )
 def test_transform_preserves_metadata_and_feature_order(mocker, result, method):
-    cart = CartMethod(regressor=StubRegressor(result), classifier=StubClassifier(result))
+    cart = CartMethod(regressor=StubRegressor(result),
+                      classifier=StubClassifier(result))
 
     cart.method_ = method
     cart.feature_names_in_ = ["b", "a"]
@@ -262,6 +299,7 @@ def test_transform_preserves_metadata_and_feature_order(mocker, result, method):
         result,
     )
 
+
 def test_transform_rejects_missing_columns():
     cart = CartMethod(regressor=StubRegressor(), classifier=StubClassifier())
 
@@ -277,15 +315,19 @@ def test_transform_rejects_missing_columns():
     ):
         cart.transform(X)
 
+
 @pytest.mark.parametrize(
     ("result", "method"),
     [
-        (pd.Series([10, 20]), StubRegressor(transform_result=np.array([10, 20]))),
-        (pd.Series(["a", "b"]), StubClassifier(transform_result=np.array(["a", "b"]))),
+        (pd.Series([10, 20]), StubRegressor(
+            transform_result=np.array([10, 20]))),
+        (pd.Series(["a", "b"]), StubClassifier(
+            transform_result=np.array(["a", "b"]))),
     ]
 )
 def test_transform_ignores_extra_columns(mocker, result, method):
-    cart = CartMethod(regressor=StubRegressor(result), classifier=StubClassifier(result))
+    cart = CartMethod(regressor=StubRegressor(result),
+                      classifier=StubClassifier(result))
 
     cart.method_ = method
     cart.feature_names_in_ = ["b", "a"]
@@ -314,17 +356,45 @@ def test_transform_ignores_extra_columns(mocker, result, method):
         X[["b", "a"]],
     )
 
+
 def test_transform_requires_fit():
     cart = CartMethod()
     with pytest.raises(NotFittedError):
         cart.transform(pd.DataFrame({"a": [1]}))
 
+
+
+@pytest.mark.parametrize(
+    "y",
+    [
+        (pd.Series([None, None, None])),
+        (pd.Series([np.nan, np.nan, np.nan])),
+        (pd.Series([pd.NA, pd.NA, pd.NA]))
+
+    ]
+)
+def test_bypass_entire_nan_array(y):
+    cart = CartMethod()
+
+    X = pd.DataFrame({
+        "a": [1, 2, 3],
+        "b": [4, 5, 6],
+    })
+
+    cart.fit(X, y)
+    result = cart.transform(X)
+
+    assert pd.isna(result).all()
+    assert len(result) == 3
 # ----- get_feature_names_out test -----
+
+
 def test_get_feature_names_out_delegates():
     cart = CartMethod()
     cart.method_ = StubRegressor()
 
     assert cart.get_feature_names_out() == ["fake_output"]
+
 
 def test_get_feature_names_out_raises_unfitted():
     cart = CartMethod()
@@ -333,6 +403,8 @@ def test_get_feature_names_out_raises_unfitted():
         cart.get_feature_names_out()
 
 # ----- clonability test -----
+
+
 def test_clone_works_and_fitted_cart_does_not_preserve_state():
     X = pd.DataFrame({"a": [1]})
     y = pd.Series([1])

--- a/tests/unit/test_tree_methods.py
+++ b/tests/unit/test_tree_methods.py
@@ -152,6 +152,7 @@ def fitted_tree(tree_method,request):
     tree_method.tree_sampler_ = tree_method.tree_sampler.clone()
     tree_method.tree_ = clone(tree_method.tree)
     tree_method.n_features_in_ = len(X.keys())
+    tree_method._all_missing = False
 
     tree_method.feature_order_ = list(X.keys())
 
@@ -503,6 +504,7 @@ def test_regressor_transform_returns_float32(leafnode_sampler):
     tree_method.tree_ = StubTree()
     tree_method.n_features_in_ = len(X.keys())
     tree_method.feature_order_ = list(X.keys())
+    tree_method._all_missing = False
     
 
     result = tree_method.transform(X)
@@ -532,13 +534,41 @@ def test_classifier_transform_returns_str_dtype(leafnode_sampler):
     tree_method.tree_ = StubTree()
     tree_method.n_features_in_ = len(X.keys())
     tree_method.feature_order_ = list(X.keys())
-    
+    tree_method._all_missing = False
 
     result = tree_method.transform(X)
 
     assert np.array_equal(result,tree_method.missing_handler_.post_synth_transform_result)
     assert result.dtype == str_dtype
 
+def test_transform_raises_not_fitted_when_missing_flag_absent():
+    X = {
+        "a": np.array([1, 2, 3]),
+        "b": np.array([4, 5, 6]),
+    }
+
+    regressor = TreeRegressorMethod()
+
+    with pytest.raises(NotFittedError):
+        regressor.transform(X)
+
+
+def test_transform_returns_nan_array_when_all_missing_true():
+    X = {
+        "a": np.array([1, 2, 3]),
+        "b": np.array([4, 5, 6]),
+    }
+
+    regressor = TreeRegressorMethod()
+
+    regressor._all_missing = True
+
+    result = regressor.transform(X)
+
+    expected = np.array([np.nan, np.nan, np.nan])
+
+    assert np.array_equal(result, expected, equal_nan=True)
+    assert result.shape == (len(X["a"]),)
 
 #general tests ------------------------------------------------------------------------------------
 
@@ -601,3 +631,4 @@ def test_to_fixed_lenght_string_array():
 
     assert result.dtype == "U2"
     assert np.array_equal(result,["aa","bb","c"])
+

--- a/tests/unit/test_tree_methods.py
+++ b/tests/unit/test_tree_methods.py
@@ -7,12 +7,18 @@ from sklearn.base import TransformerMixin, BaseEstimator
 from sklearn.exceptions import NotFittedError
 
 from synthpop.data_processing.missing_value_handling import BaseMissingValueHandler
-from synthpop.methods.cart_synth import _AbstractTreeMethod,TreeClassifierMethod, TreeRegressorMethod, _to_fixed_length_string_array
+from synthpop.methods.cart_synth import (
+    _AbstractTreeMethod,
+    TreeClassifierMethod,
+    TreeRegressorMethod,
+    _to_fixed_length_string_array,
+)
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 import copy
 
 str_dtype = np.dtypes.StringDType(na_object=np.nan)
+
 
 # stubs ---------------------------
 class TransformStub(TransformerMixin, BaseEstimator):
@@ -36,118 +42,135 @@ class TransformStub(TransformerMixin, BaseEstimator):
         self.fit_y_ = y
 
         return self.transform_return_value
-    
+
 
 @pytest.fixture
 def encoder():
-    #The result of the transform of encoding is always a 2D np.array of float32, with one or more columns
-    return TransformStub(transform_return_value=np.array([[1.1],[2.2],[3.3],[4.4],[5.5],[6.6]]))
+    # The result of the transform of encoding is always a 2D np.array of float32, with one or more columns
+    return TransformStub(
+        transform_return_value=np.array([[1.1], [2.2], [3.3], [4.4], [5.5], [6.6]])
+    )
 
 
 class StubMissingHandler(BaseMissingValueHandler):
-    
-    def __init__(self, prepared_for_fit_result,post_synth_transform_result):
+
+    def __init__(self, prepared_for_fit_result, post_synth_transform_result):
         self.prepared_for_fit_result = prepared_for_fit_result
         self.post_synth_transform_result = post_synth_transform_result
         self.clone_called = False
-    
+
     def prepare_data_for_fit(self, X, y):
         self.prepare_data_for_fit_X = X
         self.prepare_data_for_fit_y = y
         return self.prepared_for_fit_result
-    
+
     def post_synth_transform(self, X, y):
         self.post_synth_transform_X = X
         self.post_synth_transform_y = y
         return self.post_synth_transform_result
-    
+
     def clone(self):
         self.clone_called = True
         return copy.copy(self)
-    
+
     def __sklearn_clone__(self):
         return copy.copy(self)
+
 
 @pytest.fixture
 def missing_handling(request):
 
     # The result X of prepare_data_for_fit must contain the same columns as X
     X = request.node.callspec.params["X"]
-    X_prepare_res = {k:np.array([k]*3) for k in X.keys()}
-    y_prepare_res = np.arange(0,3)
+    X_prepare_res = {k: np.array([k] * 3) for k in X.keys()}
+    y_prepare_res = np.arange(0, 3)
 
-    y_post_synthesis_result = np.arange(3,6)
-    return StubMissingHandler(prepared_for_fit_result=(X_prepare_res,y_prepare_res),post_synth_transform_result=y_post_synthesis_result)
+    y_post_synthesis_result = np.arange(3, 6)
+    return StubMissingHandler(
+        prepared_for_fit_result=(X_prepare_res, y_prepare_res),
+        post_synth_transform_result=y_post_synthesis_result,
+    )
 
 
-
-class StubLeafNodeSampler():
-    def __init__(self,sample_from_leaves_return_value):
+class StubLeafNodeSampler:
+    def __init__(self, sample_from_leaves_return_value):
         self.sample_from_leaves_return_value = sample_from_leaves_return_value
         self.clone_called = False
-    
+
     def fit_sampler(self, leaf_ids: npt.ArrayLike, y: npt.ArrayLike):
         self.fit_sampler_leaf_ids = leaf_ids
         self.fit_sampler_y = y
         return self
-    
+
     def sample_from_leaves(self, leaf_ids: npt.ArrayLike) -> np.ndarray:
         self.sample_from_leaves_leaf_ids = leaf_ids
         return self.sample_from_leaves_return_value
-    
+
     def clone(self):
         self.clone_called = True
         return copy.copy(self)
 
+
 @pytest.fixture
 def leafnode_sampler():
-    return StubLeafNodeSampler(sample_from_leaves_return_value=np.array([1,2,3,4]))
+    return StubLeafNodeSampler(sample_from_leaves_return_value=np.array([1, 2, 3, 4]))
 
 
-class StubTree():
-    def __init__(self,apply_result=None):
-        self.apply_result=apply_result
+class StubTree:
+    def __init__(self, apply_result=None):
+        self.apply_result = apply_result
         pass
 
-    def fit(self,X,y):
+    def fit(self, X, y):
         self.fit_X_ = X
         self.fit_y_ = y
         return self
-    
-    def apply(self,X):
+
+    def apply(self, X):
         self.apply_X_ = X
         return self.apply_result
+
     def __sklearn_clone__(self):
         return copy.copy(self)
 
-class TestTreeMethod(_AbstractTreeMethod):
-    def __init__(self, *,
-                 encoder = None,
-                missing_handling = None,
-                tree_sampler = None,
-                tree = None):
-        super().__init__(encoder=encoder, missing_handler=missing_handling, tree_sampler=tree_sampler,tree=tree)
 
+class TestTreeMethod(_AbstractTreeMethod):
+    def __init__(
+        self, *, encoder=None, missing_handling=None, tree_sampler=None, tree=None
+    ):
+        super().__init__(
+            encoder=encoder,
+            missing_handler=missing_handling,
+            tree_sampler=tree_sampler,
+            tree=tree,
+        )
 
     def _get_encoder(self):
         return TransformStub()
-    
+
     def _get_tree(self):
         return StubTree()
-    
+
     def _get_missing_handling(self):
         return super()._get_missing_handling()
-    
+
+
 @pytest.fixture
-def tree_method(encoder,missing_handling,leafnode_sampler):
-    return TestTreeMethod(encoder=encoder,missing_handling=missing_handling,tree_sampler=leafnode_sampler,tree=StubTree())
+def tree_method(encoder, missing_handling, leafnode_sampler):
+    return TestTreeMethod(
+        encoder=encoder,
+        missing_handling=missing_handling,
+        tree_sampler=leafnode_sampler,
+        tree=StubTree(),
+    )
+
 
 @pytest.fixture()
-def fitted_tree(tree_method,request):
+def fitted_tree(tree_method, request):
 
     X = request.node.callspec.params["X"]
     cat_index = request.node.callspec.params["index_cat"]
-    tree_method.encoders_ =  {k:clone(tree_method.encoder) for k in cat_index}
+    tree_method.encoders_ = {k: clone(tree_method.encoder) for k in cat_index}
     tree_method.missing_handler_ = tree_method.missing_handler.clone()
     tree_method.tree_sampler_ = tree_method.tree_sampler.clone()
     tree_method.tree_ = clone(tree_method.tree)
@@ -159,15 +182,20 @@ def fitted_tree(tree_method,request):
     return tree_method
 
 
+# ---------------------------------------------------
 
-#---------------------------------------------------
 
-def assert_dict_array_equal(expected,actual):
+def assert_dict_array_equal(expected, actual):
 
-    for (k,v) in expected.items():
-        assert np.array_equal(v,actual[k],equal_nan=True), f"expected (key = {k}): {v}. Actual: {actual[k]}"
+    for k, v in expected.items():
+        assert np.array_equal(
+            v, actual[k], equal_nan=True
+        ), f"expected (key = {k}): {v}. Actual: {actual[k]}"
 
-    assert len(expected.keys()) == len(actual.keys()), f"actual has more keys than expected. Expected: {len(expected.keys())}. Actual: {actual.keys()}"
+    assert len(expected.keys()) == len(
+        actual.keys()
+    ), f"actual has more keys than expected. Expected: {len(expected.keys())}. Actual: {actual.keys()}"
+
 
 # Test data ---------------------------------------------------------------------------------------
 
@@ -175,341 +203,418 @@ def assert_dict_array_equal(expected,actual):
 def get_input_test_data():
 
     X1 = {
-        "num_1":np.array([1,2,np.nan,2,5,3]),
-        "cat_1":np.array(["a","b","c","d","e","f"],dtype=str_dtype),
-        "num_2":np.array([1.1,2.2,5.5,2.2,5.5,3.3]),
-        "cat_2":np.array(["aa","bc","cc","dD","eE","fF"],dtype=str_dtype),
+        "num_1": np.array([1, 2, np.nan, 2, 5, 3]),
+        "cat_1": np.array(["a", "b", "c", "d", "e", "f"], dtype=str_dtype),
+        "num_2": np.array([1.1, 2.2, 5.5, 2.2, 5.5, 3.3]),
+        "cat_2": np.array(["aa", "bc", "cc", "dD", "eE", "fF"], dtype=str_dtype),
     }
 
     X2 = {
-        "num_1":np.array([1,2,5,2,5,3]),
-        "num_2":np.array([1.1,2.2,5.5,2.2,5.5,3.3]),
+        "num_1": np.array([1, 2, 5, 2, 5, 3]),
+        "num_2": np.array([1.1, 2.2, 5.5, 2.2, 5.5, 3.3]),
     }
 
     X3 = {
-        "cat_1":np.array(["a","b","c","d","e","f"]),
-        "cat_2":np.array(["aa","bc","cc","dD","eE","fF"]),
+        "cat_1": np.array(["a", "b", "c", "d", "e", "f"]),
+        "cat_2": np.array(["aa", "bc", "cc", "dD", "eE", "fF"]),
     }
 
-    y1 = np.array([1.2,2.3,3.4,5.6,7.8,8.9])
-    y2 = np.array(["a","b","c","d","e","f"],dtype=str_dtype)
-
+    y1 = np.array([1.2, 2.3, 3.4, 5.6, 7.8, 8.9])
+    y2 = np.array(["a", "b", "c", "d", "e", "f"], dtype=str_dtype)
 
     # Some tests need a ground truth of which columns are categorical.
     # That is why a list of categorical columns is supplied to each test.
-    base_cases_numpy = [ (X1,y1,["cat_1","cat_2"]),
-                        (X2,y2,[]),
-                        (X3,y1,["cat_1","cat_2"]),
-                        ]
+    base_cases_numpy = [
+        (X1, y1, ["cat_1", "cat_2"]),
+        (X2, y2, []),
+        (X3, y1, ["cat_1", "cat_2"]),
+    ]
 
     return base_cases_numpy
 
+
 def get_exp_feature_matrix():
-    return np.array([[1,2],[3,4]])
+    return np.array([[1, 2], [3, 4]])
+
+
 # Fixtures ----------------------------------------------------------------------------------------
 
 
 @pytest.fixture
 def apply_result(missing_handling):
     n = len(missing_handling.prepared_for_fit_result[0])
-    apply_result = np.array([i%3 for i in range(n)])
+    apply_result = np.array([i % 3 for i in range(n)])
     return apply_result
 
 
 @pytest.fixture(autouse=True)
-def stub_build_feature_matrix(request,monkeypatch):
+def stub_build_feature_matrix(request, monkeypatch):
     # The test should not use the real implementation of build_feature_matrix.
     # The test should use a stub of that function instead.
     # There is one exception to this: the standard tests of sklearn do need the real build_feature_matrix.
 
     # setting autouse=True causes this fixture to be used in every test.
     # to enable the exception, we check for the 'noautofixt' mark.
-    if 'noautofixt' in request.keywords:
+    if "noautofixt" in request.keywords:
         return
-    
-    #We need to import tree utils here so that we can replace build_feature_matrix with our stub.
+
+    # We need to import tree utils here so that we can replace build_feature_matrix with our stub.
     from synthpop.methods import tree_utils
 
     # We define the stub
-    def stub_build_feature_matrix(X,feature_order):
+    def stub_build_feature_matrix(X, feature_order):
         return get_exp_feature_matrix()
-    
+
     # and use monkey patching to replace the method with the stub.
-    monkeypatch.setattr(tree_utils,"build_feature_matrix",stub_build_feature_matrix)
+    monkeypatch.setattr(tree_utils, "build_feature_matrix", stub_build_feature_matrix)
+
 
 @pytest.fixture(autouse=True)
-def stub_validate_dict(request,monkeypatch):
+def stub_validate_dict(request, monkeypatch):
 
     # validating the input is delegated to functions in utils.py.
     # So for these unit test, we need to stub those functions
 
     # setting autouse=True causes this fixture to be used in every test.
     # to enable the exception, we check for the 'noautofixt' mark.
-    if 'noautofixt' in request.keywords:
+    if "noautofixt" in request.keywords:
         return
-    
-    #We need to import tree utils here so that we can replace build_feature_matrix with our stub.
+
+    # We need to import tree utils here so that we can replace build_feature_matrix with our stub.
     from synthpop import utils
 
     # and use monkey patching to replace the method with the stub.
-    monkeypatch.setattr(utils,"validate_2d_dict",lambda X: (X,42))
-    monkeypatch.setattr(utils,"validate_1d_target",lambda y,n_samples: y)
+    monkeypatch.setattr(utils, "validate_2d_dict", lambda X: (X, 42))
+    monkeypatch.setattr(utils, "validate_1d_target", lambda y, n_samples: y)
 
 
 # test fit ----------------------------------------------------------------------------------------
 # Note: raising errors on bad shapes is delegated to utils.validate_dict_x and utils.validate_y
 # In the unit tests of tree methods, we only check that de delegation happens.
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_validates_X_and_y(X,y,index_cat,tree_method,mocker):
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_validates_X_and_y(X, y, index_cat, tree_method, mocker):
     from synthpop import utils
 
-    X_spy = mocker.spy(utils,"validate_2d_dict")
-    y_spy = mocker.spy(utils,"validate_1d_target")
+    X_spy = mocker.spy(utils, "validate_2d_dict")
+    y_spy = mocker.spy(utils, "validate_1d_target")
 
-    tree_method.fit(X,y)
+    tree_method.fit(X, y)
 
     X_spy.assert_called_once_with(X)
-    y_spy.assert_called_once_with(y,42)#42 is the hardcoded n_samples value of the validate_dict_x stub
+    y_spy.assert_called_once_with(
+        y, 42
+    )  # 42 is the hardcoded n_samples value of the validate_dict_x stub
+
 
 @pytest.mark.parametrize("X, y, index_cat", get_input_test_data())
 def test_fit_clones_dependencies_correctly(X, y, index_cat, tree_method):
 
-    tree_method.fit(X,y)
+    tree_method.fit(X, y)
     assert tree_method.missing_handler.clone_called
     assert tree_method.tree_sampler.clone_called
 
 
-
-
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_n_features_in(X,y,index_cat,tree_method):
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_n_features_in(X, y, index_cat, tree_method):
 
     tree_method.fit(X, y)
     assert tree_method.n_features_in_ == len(X)
 
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_trains_encoder(X,y,index_cat,tree_method):
 
-    
-    tree_method.fit(X,y)
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_trains_encoder(X, y, index_cat, tree_method):
+
+    tree_method.fit(X, y)
 
     for i in index_cat:
-        assert np.array_equal(tree_method.encoders_[i].fit_X_,X[i])
-        assert np.array_equal(tree_method.encoders_[i].fit_y_,y)
-        assert not ( tree_method.encoders_[i] is tree_method.encoder)
+        assert np.array_equal(tree_method.encoders_[i].fit_X_, X[i])
+        assert np.array_equal(tree_method.encoders_[i].fit_y_, y)
+        assert not (tree_method.encoders_[i] is tree_method.encoder)
 
         for i2 in index_cat:
-            assert (not ( tree_method.encoders_[i] is tree_method.encoders_[i2])) or i2==i
+            assert (
+                not (tree_method.encoders_[i] is tree_method.encoders_[i2])
+            ) or i2 == i
 
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_transforms_with_encoder(X,y,index_cat,tree_method):
 
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_transforms_with_encoder(X, y, index_cat, tree_method):
 
-    tree_method.fit(X,y)
+    tree_method.fit(X, y)
 
     for i in index_cat:
-        assert np.array_equal(tree_method.encoders_[i].transform_X_,tree_method.missing_handler_.prepared_for_fit_result[0][i])
+        assert np.array_equal(
+            tree_method.encoders_[i].transform_X_,
+            tree_method.missing_handler_.prepared_for_fit_result[0][i],
+        )
 
 
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_prepare_data_for_fit_is_called(X,y,index_cat,tree_method):
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_prepare_data_for_fit_is_called(X, y, index_cat, tree_method):
 
-    tree_method.fit(X,y)
+    tree_method.fit(X, y)
 
-    assert_dict_array_equal(expected=X,actual=tree_method.missing_handler_.prepare_data_for_fit_X)
+    assert_dict_array_equal(
+        expected=X, actual=tree_method.missing_handler_.prepare_data_for_fit_X
+    )
 
-    assert np.array_equal(tree_method.missing_handler_.prepare_data_for_fit_y,y)
+    assert np.array_equal(tree_method.missing_handler_.prepare_data_for_fit_y, y)
     assert not (tree_method.missing_handler_ is tree_method.missing_handler)
 
-@pytest.mark.parametrize("X,y",[(v[0],v[1]) for v in get_input_test_data()])
-def test_fit_sets_order(X,y,tree_method):
 
-    tree_method.fit(X,y)
+@pytest.mark.parametrize("X,y", [(v[0], v[1]) for v in get_input_test_data()])
+def test_fit_sets_order(X, y, tree_method):
+
+    tree_method.fit(X, y)
 
     assert list(X.keys()) == tree_method.feature_order_
 
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_build_feature_matrix(X,y,index_cat,tree_method,mocker):
+
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_build_feature_matrix(X, y, index_cat, tree_method, mocker):
     from synthpop.methods import tree_utils
 
-    spy = mocker.spy(tree_utils,"build_feature_matrix")
+    spy = mocker.spy(tree_utils, "build_feature_matrix")
 
-    tree_method.fit(X,y)
-    X_exp = {k: tree_method.encoders_[k].transform_return_value if k in index_cat else v for (k,v) in tree_method.missing_handler_.prepared_for_fit_result[0].items()}
+    tree_method.fit(X, y)
+    X_exp = {
+        k: tree_method.encoders_[k].transform_return_value if k in index_cat else v
+        for (k, v) in tree_method.missing_handler_.prepared_for_fit_result[0].items()
+    }
 
     expected_order = tree_method.feature_order_
-    spy.assert_called_once_with(X_exp,expected_order)
-    
-
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_tree_is_fit(X,y,index_cat,tree_method):
+    spy.assert_called_once_with(X_exp, expected_order)
 
 
-    tree_method.fit(X,y)
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_tree_is_fit(X, y, index_cat, tree_method):
 
-    assert np.array_equal(get_exp_feature_matrix(),tree_method.tree_.fit_X_,equal_nan=True)
+    tree_method.fit(X, y)
 
-    assert np.array_equal(tree_method.missing_handler_.prepared_for_fit_result[1],tree_method.tree_.fit_y_)
+    assert np.array_equal(
+        get_exp_feature_matrix(), tree_method.tree_.fit_X_, equal_nan=True
+    )
 
-
-
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_tree_is_applied(X,y,index_cat,tree_method):
-
-    tree_method.fit(X,y)
-
-    assert np.array_equal(get_exp_feature_matrix(),tree_method.tree_.apply_X_,equal_nan=True)
+    assert np.array_equal(
+        tree_method.missing_handler_.prepared_for_fit_result[1],
+        tree_method.tree_.fit_y_,
+    )
 
 
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_sampler_fit(X,y,index_cat,tree_method):
-    tree_method.fit(X,y)
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_tree_is_applied(X, y, index_cat, tree_method):
 
-    assert np.array_equal(tree_method.tree_sampler_.fit_sampler_leaf_ids,tree_method.tree_.apply_result), "input of the sampler must be the output of the tree"
-    assert np.array_equal(tree_method.tree_sampler_.fit_sampler_y,tree_method.missing_handler_.prepared_for_fit_result[1])
+    tree_method.fit(X, y)
+
+    assert np.array_equal(
+        get_exp_feature_matrix(), tree_method.tree_.apply_X_, equal_nan=True
+    )
+
+
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_sampler_fit(X, y, index_cat, tree_method):
+    tree_method.fit(X, y)
+
+    assert np.array_equal(
+        tree_method.tree_sampler_.fit_sampler_leaf_ids, tree_method.tree_.apply_result
+    ), "input of the sampler must be the output of the tree"
+    assert np.array_equal(
+        tree_method.tree_sampler_.fit_sampler_y,
+        tree_method.missing_handler_.prepared_for_fit_result[1],
+    )
     assert not (tree_method.tree_sampler is tree_method.tree_sampler_)
 
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_set_feature_names_out(X,y,index_cat,tree_method):
 
-    y = pd.Series(y,name="target_name")
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_set_feature_names_out(X, y, index_cat, tree_method):
 
-    tree_method.fit(X,y)
+    y = pd.Series(y, name="target_name")
+
+    tree_method.fit(X, y)
 
     assert tree_method.target_name_ == "target_name"
 
-@pytest.mark.parametrize("X,y,index_cat",get_input_test_data())
-def test_fit_set_feature_names_out_no_target_name(X,y,index_cat,tree_method):
 
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_fit_set_feature_names_out_no_target_name(X, y, index_cat, tree_method):
 
-    tree_method.fit(X,y)
+    tree_method.fit(X, y)
 
     assert tree_method.target_name_ is None
 
-def test_fit_classifier_converts_to_str(encoder,leafnode_sampler,mocker):
-    X = {"a":np.array([1,2])}
-    y = np.array(["a","b"],dtype=str_dtype)
+
+def test_fit_classifier_converts_to_str(encoder, leafnode_sampler, mocker):
+    X = {"a": np.array([1, 2])}
+    y = np.array(["a", "b"], dtype=str_dtype)
 
     # the missing handling can return a y of str_dtype.
-    missing_handling = StubMissingHandler(prepared_for_fit_result=(X,y),post_synth_transform_result=None)
-    
-    str_y = np.array(["x","y"])
-    mocked_to_str= mocker.patch('synthpop.methods.cart_synth._to_fixed_length_string_array',return_value=str_y)
+    missing_handling = StubMissingHandler(
+        prepared_for_fit_result=(X, y), post_synth_transform_result=None
+    )
 
-    tree_method = TreeClassifierMethod(encoder=encoder,missing_handler=missing_handling,tree_sampler=leafnode_sampler,tree=StubTree())
-    
+    str_y = np.array(["x", "y"])
+    mocked_to_str = mocker.patch(
+        "synthpop.methods.cart_synth._to_fixed_length_string_array", return_value=str_y
+    )
 
-    tree_method.fit(X,y)
+    tree_method = TreeClassifierMethod(
+        encoder=encoder,
+        missing_handler=missing_handling,
+        tree_sampler=leafnode_sampler,
+        tree=StubTree(),
+    )
+
+    tree_method.fit(X, y)
 
     mocked_to_str.assert_called_with(y)
-    assert np.array_equal(str_y,tree_method.tree_.fit_y_)
-    
-def test_fit_regressor_converts_to_float32(encoder,leafnode_sampler):
-    X = {"a":np.array([1,2])}
-    y = np.array([1,2.0],dtype=np.float64)
+    assert np.array_equal(str_y, tree_method.tree_.fit_y_)
+
+
+def test_fit_regressor_converts_to_float32(encoder, leafnode_sampler):
+    X = {"a": np.array([1, 2])}
+    y = np.array([1, 2.0], dtype=np.float64)
 
     # the missing handling can return a y of np.float64
-    missing_handling = StubMissingHandler(prepared_for_fit_result=(X,y),post_synth_transform_result=None)
-    
-    converted_y = np.array([1,2.0],dtype=np.float32)
+    missing_handling = StubMissingHandler(
+        prepared_for_fit_result=(X, y), post_synth_transform_result=None
+    )
 
-    tree_method = TreeRegressorMethod(encoder=encoder,missing_handler=missing_handling,tree_sampler=leafnode_sampler,tree=StubTree())
-    
+    converted_y = np.array([1, 2.0], dtype=np.float32)
 
-    tree_method.fit(X,y)
+    tree_method = TreeRegressorMethod(
+        encoder=encoder,
+        missing_handler=missing_handling,
+        tree_sampler=leafnode_sampler,
+        tree=StubTree(),
+    )
 
-    assert np.array_equal(converted_y,tree_method.tree_.fit_y_)
+    tree_method.fit(X, y)
+
+    assert np.array_equal(converted_y, tree_method.tree_.fit_y_)
     assert tree_method.tree_.fit_y_.dtype == np.float32
 
-    
 
+@pytest.mark.parametrize("X,y,index_cat", get_input_test_data())
+def test_tree_method_fit_returns_nan_for_nan_array(X, y, index_cat, tree_method):
+    y = np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
+
+    fitted = tree_method.fit(X,y)
+
+    assert fitted._all_missing
+    assert not hasattr(fitted, "encoders_")
+    assert not hasattr(fitted, "missing_handler_")
+    assert not hasattr(fitted, "tree_")
+    assert not hasattr(fitted, "tree_sampler_")
 # test transform ----------------------------------------------------------------------------------
 
 
-
-@pytest.mark.parametrize("X,index_cat",[(v[0],v[2]) for v in get_input_test_data()])
-def test_transform_encodes_data(X,index_cat,fitted_tree):
+@pytest.mark.parametrize("X,index_cat", [(v[0], v[2]) for v in get_input_test_data()])
+def test_transform_encodes_data(X, index_cat, fitted_tree):
 
     fitted_tree.transform(X)
 
     for i in index_cat:
-        assert isinstance(fitted_tree.encoders_[i].transform_X_,np.ndarray)
-        assert np.array_equal(X[i],fitted_tree.encoders_[i].transform_X_)
+        assert isinstance(fitted_tree.encoders_[i].transform_X_, np.ndarray)
+        assert np.array_equal(X[i], fitted_tree.encoders_[i].transform_X_)
 
 
-@pytest.mark.parametrize("X,index_cat",[(v[0],v[2]) for v in get_input_test_data()])
-def test_transform_build_feature_matrix(X,index_cat,fitted_tree,mocker):
+@pytest.mark.parametrize("X,index_cat", [(v[0], v[2]) for v in get_input_test_data()])
+def test_transform_build_feature_matrix(X, index_cat, fitted_tree, mocker):
     from synthpop.methods import tree_utils
 
-    spy = mocker.spy(tree_utils,"build_feature_matrix")
-    tree_method = fitted_tree 
+    spy = mocker.spy(tree_utils, "build_feature_matrix")
+    tree_method = fitted_tree
 
     # we need to verify that the feature order seen when fitting is used.
     # setting feature_order_ to a random sequence guarantees that the tree method uses feature_order_ and does not use list(X.keys())
-    tree_method.feature_order_ = ["some","random","order"]
+    tree_method.feature_order_ = ["some", "random", "order"]
 
     tree_method.transform(X)
-    X_exp = {k: tree_method.encoders_[k].transform_return_value if k in index_cat else v for (k,v) in X.items()}
-    spy.assert_called_once_with(X_exp,tree_method.feature_order_ )
+    X_exp = {
+        k: tree_method.encoders_[k].transform_return_value if k in index_cat else v
+        for (k, v) in X.items()
+    }
+    spy.assert_called_once_with(X_exp, tree_method.feature_order_)
 
-@pytest.mark.parametrize("X,index_cat",[(v[0],v[2]) for v in get_input_test_data()])
-def test_transform_applies_fitted_tree(X,index_cat,fitted_tree):
-    tree_method =fitted_tree
+
+@pytest.mark.parametrize("X,index_cat", [(v[0], v[2]) for v in get_input_test_data()])
+def test_transform_applies_fitted_tree(X, index_cat, fitted_tree):
+    tree_method = fitted_tree
 
     tree_method.transform(X)
 
     expected_input_for_tree = get_exp_feature_matrix()
 
-    assert np.array_equal(expected_input_for_tree,tree_method.tree_.apply_X_,equal_nan=True)
+    assert np.array_equal(
+        expected_input_for_tree, tree_method.tree_.apply_X_, equal_nan=True
+    )
 
 
+@pytest.mark.parametrize("X,index_cat", [(v[0], v[2]) for v in get_input_test_data()])
+def test_transform_uses_sampler(X, index_cat, fitted_tree):
 
-@pytest.mark.parametrize("X,index_cat",[(v[0],v[2]) for v in get_input_test_data()])
-def test_transform_uses_sampler(X,index_cat,fitted_tree):
-
-    tree_method =fitted_tree
+    tree_method = fitted_tree
 
     tree_method.transform(X)
 
-    assert np.array_equal(tree_method.tree_.apply_result,tree_method.tree_sampler_.sample_from_leaves_leaf_ids)
+    assert np.array_equal(
+        tree_method.tree_.apply_result,
+        tree_method.tree_sampler_.sample_from_leaves_leaf_ids,
+    )
 
-@pytest.mark.parametrize("X,index_cat",[(v[0],v[2]) for v in get_input_test_data()])
-def test_transform_calls_post_synth_transform(X,index_cat,fitted_tree):
-    
+
+@pytest.mark.parametrize("X,index_cat", [(v[0], v[2]) for v in get_input_test_data()])
+def test_transform_calls_post_synth_transform(X, index_cat, fitted_tree):
+
     tree_method = fitted_tree
 
     result = tree_method.transform(X)
 
     assert_dict_array_equal(X, tree_method.missing_handler_.post_synth_transform_X)
-    assert np.array_equal(tree_method.tree_sampler_.sample_from_leaves_return_value,tree_method.missing_handler_.post_synth_transform_y)
-    assert np.array_equal(result, tree_method.missing_handler_.post_synth_transform_result)
+    assert np.array_equal(
+        tree_method.tree_sampler_.sample_from_leaves_return_value,
+        tree_method.missing_handler_.post_synth_transform_y,
+    )
+    assert np.array_equal(
+        result, tree_method.missing_handler_.post_synth_transform_result
+    )
 
-@pytest.mark.parametrize("X",[v[0] for v in get_input_test_data()])
-def test_transform_raises_error_when_not_fitted(X,tree_method):
-    
+
+@pytest.mark.parametrize("X", [v[0] for v in get_input_test_data()])
+def test_transform_raises_error_when_not_fitted(X, tree_method):
+
     with pytest.raises(NotFittedError):
         tree_method.transform(X)
 
+
 def test_regressor_transform_returns_float32(leafnode_sampler):
-    X = {"a":np.array([1,2])}
-    y = np.array([1,2.0],dtype=np.float64)
+    X = {"a": np.array([1, 2])}
+    y = np.array([1, 2.0], dtype=np.float64)
 
     # the missing handling can return a y of np.float64
-    missing_handling = StubMissingHandler(prepared_for_fit_result=None,post_synth_transform_result=y)
-    
-    tree_method = TreeRegressorMethod(encoder=None,missing_handler=missing_handling,tree_sampler=leafnode_sampler,tree=StubTree())
-    tree_method.encoders_ =  {}
+    missing_handling = StubMissingHandler(
+        prepared_for_fit_result=None, post_synth_transform_result=y
+    )
+
+    tree_method = TreeRegressorMethod(
+        encoder=None,
+        missing_handler=missing_handling,
+        tree_sampler=leafnode_sampler,
+        tree=StubTree(),
+    )
+    tree_method.encoders_ = {}
     tree_method.missing_handler_ = missing_handling
     tree_method.tree_sampler_ = leafnode_sampler
     tree_method.tree_ = StubTree()
     tree_method.n_features_in_ = len(X.keys())
     tree_method.feature_order_ = list(X.keys())
     tree_method._all_missing = False
-    
 
     result = tree_method.transform(X)
 
-    assert np.array_equal(result,tree_method.missing_handler_.post_synth_transform_result)
+    assert np.array_equal(
+        result, tree_method.missing_handler_.post_synth_transform_result
+    )
     assert result.dtype == np.float32
 
 
@@ -520,15 +625,22 @@ def test_classifier_transform_returns_str_dtype(leafnode_sampler):
     However, if MissingValuePredictor is used as missing handler, it might happen that the output is not already str_dtype.
     Since the consequence of such an unexpected dtype could be that np.nan becomes "NaN" (which would be a silent error), we need to explicitly deal with this situation.
     """
-    
-    X = {"a":np.array([1,2])}
-    y = np.array(["a","b"],dtype=np.str_)
+
+    X = {"a": np.array([1, 2])}
+    y = np.array(["a", "b"], dtype=np.str_)
 
     # the missing handling can return a y of np.float64
-    missing_handling = StubMissingHandler(prepared_for_fit_result=None,post_synth_transform_result=y)
-    
-    tree_method = TreeClassifierMethod(encoder=None,missing_handler=missing_handling,tree_sampler=leafnode_sampler,tree=StubTree())
-    tree_method.encoders_ =  {}
+    missing_handling = StubMissingHandler(
+        prepared_for_fit_result=None, post_synth_transform_result=y
+    )
+
+    tree_method = TreeClassifierMethod(
+        encoder=None,
+        missing_handler=missing_handling,
+        tree_sampler=leafnode_sampler,
+        tree=StubTree(),
+    )
+    tree_method.encoders_ = {}
     tree_method.missing_handler_ = missing_handling
     tree_method.tree_sampler_ = leafnode_sampler
     tree_method.tree_ = StubTree()
@@ -538,8 +650,11 @@ def test_classifier_transform_returns_str_dtype(leafnode_sampler):
 
     result = tree_method.transform(X)
 
-    assert np.array_equal(result,tree_method.missing_handler_.post_synth_transform_result)
+    assert np.array_equal(
+        result, tree_method.missing_handler_.post_synth_transform_result
+    )
     assert result.dtype == str_dtype
+
 
 def test_transform_raises_not_fitted_when_missing_flag_absent():
     X = {
@@ -553,48 +668,51 @@ def test_transform_raises_not_fitted_when_missing_flag_absent():
         regressor.transform(X)
 
 
-def test_transform_returns_nan_array_when_all_missing_true():
-    X = {
-        "a": np.array([1, 2, 3]),
-        "b": np.array([4, 5, 6]),
-    }
+@pytest.mark.parametrize("X,index_cat", [(v[0], v[2]) for v in get_input_test_data()])
+def test_transform_returns_nan_array_when_all_missing_true(X, index_cat, fitted_tree):
 
-    regressor = TreeRegressorMethod()
+    fitted_tree._all_missing = True
 
-    regressor._all_missing = True
+    result = fitted_tree.transform(X)
 
-    result = regressor.transform(X)
-
-    expected = np.array([np.nan, np.nan, np.nan])
+    expected = np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
 
     assert np.array_equal(result, expected, equal_nan=True)
-    assert result.shape == (len(X["a"]),)
 
-#general tests ------------------------------------------------------------------------------------
 
-@pytest.mark.parametrize("X",[v[0] for v in get_input_test_data()])
-def test_get_feature_names_out(X,tree_method):
+# general tests ------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("X", [v[0] for v in get_input_test_data()])
+def test_get_feature_names_out(X, tree_method):
     tree_method.target_name_ = "name_of_target"
 
     result = tree_method.get_feature_names_out()
     assert result == ["name_of_target"]
 
-@pytest.mark.parametrize("X",[v[0] for v in get_input_test_data()])
-def test_get_feature_names_out_no_target_name(X,tree_method):
+
+@pytest.mark.parametrize("X", [v[0] for v in get_input_test_data()])
+def test_get_feature_names_out_no_target_name(X, tree_method):
     tree_method.target_name_ = None
-    tree_method.feature_order_ = ["Trained","on","these","features"]
+    tree_method.feature_order_ = ["Trained", "on", "these", "features"]
 
     result = tree_method.get_feature_names_out()
-    assert result == [["Trained","on","these","features"]]
+    assert result == [["Trained", "on", "these", "features"]]
 
 
 def ndarray_to_dict(a):
-    if isinstance(a,np.ndarray):
-        return {i: a[:,i] for i in range(a.shape[1])}
+    if isinstance(a, np.ndarray):
+        return {i: a[:, i] for i in range(a.shape[1])}
     return a
-@parametrize_with_checks([TreeClassifierMethod(),TreeRegressorMethod()], legacy=False, expected_failed_checks=lambda x: {
-    "check_fit_score_takes_y":"tests with a score component"
-})
+
+
+@parametrize_with_checks(
+    [TreeClassifierMethod(), TreeRegressorMethod()],
+    legacy=False,
+    expected_failed_checks=lambda x: {
+        "check_fit_score_takes_y": "tests with a score component"
+    },
+)
 @pytest.mark.noautofixt
 def test_TreeMethod_is_sklearn_compatible(estimator, check):
     # sklearn provides valuable tests.
@@ -607,28 +725,28 @@ def test_TreeMethod_is_sklearn_compatible(estimator, check):
     # The solution is that a class is constructed in each sklearn test.
     # This class inherits from the applicable tree method, and overwrites the fit and transform to convert np arrays to dictionaries.
     class EstimatorWrap(estimator.__class__):
-        def fit(self,X,y):
-            return super().fit(ndarray_to_dict(X),y)
-        
-        def transform(self,X):
+        def fit(self, X, y):
+            return super().fit(ndarray_to_dict(X), y)
+
+        def transform(self, X):
             return super().transform(ndarray_to_dict(X))
-        
-    #This is needed to change the datatype of the estimator to the child class.
-    #estimator.__class__ = EstimatorWrap
+
+    # This is needed to change the datatype of the estimator to the child class.
+    # estimator.__class__ = EstimatorWrap
     wrapped = EstimatorWrap(**estimator.get_params())
 
     check(wrapped)
 
+
 def test_to_fixed_lenght_string_array():
-    x = np.array(["a","b"],dtype=str_dtype)
+    x = np.array(["a", "b"], dtype=str_dtype)
     result = _to_fixed_length_string_array(x)
 
     assert result.dtype == "U1"
-    assert np.array_equal(result,["a","b"])
+    assert np.array_equal(result, ["a", "b"])
 
-    x = np.array(["aa","bb","c"],dtype=str_dtype)
+    x = np.array(["aa", "bb", "c"], dtype=str_dtype)
     result = _to_fixed_length_string_array(x)
 
     assert result.dtype == "U2"
-    assert np.array_equal(result,["aa","bb","c"])
-
+    assert np.array_equal(result, ["aa", "bb", "c"])


### PR DESCRIPTION
First version to create a work around for an entire nan array input in CART Method.

I added an attribute: self.method_._all_missing for continuity with BaseMissingValueHandler, which also stores this attribute. Please be very critical on whether this is a good idea.

There is also two tests included that particularly checks whether the fitting is skipped in cart.fit, and one that checks whether the transformation returns the desired output. 

Important to note is that there was a little work-around required due to the check_is_fitted(), as that raises errors.

I also added self._all_missing = False to the StubClassifier/Regressor classes for testing, else the code breaks for the stubs not having the attribute.
